### PR TITLE
Avoid DatabaseCleaner leak to global scope

### DIFF
--- a/lib/database-cleaner.js
+++ b/lib/database-cleaner.js
@@ -1,4 +1,4 @@
-module.exports = DatabaseCleaner = function(type) {
+var DatabaseCleaner = module.exports = function(type) {
   var cleaner = {};
 
   cleaner['mongodb'] = function(db, callback) {


### PR DESCRIPTION
When using [hapijs/lab](https://github.com/hapijs/lab) the coverage test reports that DatabaseCleaner is being 'leak'.

`The following leaks were detected:DatabaseCleaner`
