### PR TITLE
Quote table names for postgresql.

### DIFF
--- a/lib/database-cleaner.js
+++ b/lib/database-cleaner.js
@@ -60,7 +60,7 @@ var DatabaseCleaner = module.exports = function(type) {
 
       tables.rows.forEach(function(table) {
         if (table['table_name'] != 'schema_migrations') {
-          db.query("DELETE FROM " + table['table_name'], function() {
+          db.query("DELETE FROM " + '"' + table['table_name'] + '"', function() {
             count++;
             if (count >= length) {
               callback.apply();


### PR DESCRIPTION
I ran into the issue where a framework is using the table "user" for user storage which I wanted to clean on every step. Problem is that without quotes the query will try to wipe the postgres roles.