### PR TITLE
Add support for specifying postgres schema

### DIFF
--- a/lib/database-cleaner.js
+++ b/lib/database-cleaner.js
@@ -88,7 +88,10 @@ var DatabaseCleaner = module.exports = function(type, config) {
   };
 
   cleaner['postgresql'] = function(db, callback) {
-    db.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';", function(err, tables) {
+    var schema = config.postgresql.schema || 'public';
+    var schemaPrefix = '"' + schema + '".';
+
+    db.query("SELECT table_name FROM information_schema.tables WHERE table_schema = '" + schema + "';", function(err, tables) {
       if (err) return callback(err);
 
       var count  = 0;
@@ -107,7 +110,7 @@ var DatabaseCleaner = module.exports = function(type, config) {
       if (strategy === 'deletion') {
         tables.rows.forEach(function(table) {
           if (skippedTables.indexOf(table['table_name']) === -1) {
-            db.query("DELETE FROM " + "\"" + table['table_name'] + "\"", function() {
+            db.query("DELETE FROM " + schemaPrefix + "\"" + table['table_name'] + "\"", function() {
               count++;
 
               if (count >= length) {
@@ -126,7 +129,7 @@ var DatabaseCleaner = module.exports = function(type, config) {
                                 .filter(function(table) {
                                   return skippedTables.indexOf(table['table_name']) === -1;
                                 }).map(function(table) {
-                                  return '"' + table['table_name'] + '"';
+                                  return schemaPrefix + '"' + table['table_name'] + '"';
                                 }).join(', ');
 
         // no tables to truncate


### PR DESCRIPTION
When working with database schema other than `public` (the default), it is desirable to specify which schema to target for cleaning tables. This adds support for passing a `schema` property in the `postgresql` config argument of the `DatabaseCleaner` constructor.

Example:

```javascript
var config = {
  postgresql: {
    strategy: 'truncation',
    skipTables: [],
    schema: 'other_schema'
  }
};

databaseCleaner = new DatabaseCleaner('postgresql', config);
```

When specifying a `schema`, _only_ the specified schema will be cleaned. When _not_  specifying a `schema`, _only_ the `public` schema will be cleaned (matches the current behavior).