### PR TITLE
Make mysql work for some special cases (database case, views, foreign keys)

### DIFF
--- a/lib/database-cleaner.js
+++ b/lib/database-cleaner.js
@@ -47,45 +47,50 @@ var DatabaseCleaner = module.exports = function(type, config) {
   };
 
   cleaner['mysql'] = function(db, callback) {
-    db.query('show tables', function(err, tables) {
-      if (err) return callback(err);
+    db.query('show global variables like "lower_case_table_names"', function(err, values) {
 
-      var database = db.config.connectionConfig ?
-        db.config.connectionConfig.database : db.config.database;
+      var lowerCaseTableNames = values[0]['Value'] === 2;
 
-      var count  = 0;
-      var length = tables.length;
-      var tableName = 'Tables_in_' + database;
-      var skippedTables = config.mysql.skipTables;
-      var strategy = config.mysql.strategy || 'deletion';
-      if (strategy !== 'deletion' && strategy !== 'truncation') {
-        return callback(new Error('Invalid deletion strategy: ' + strategy));
-      }
+      db.query('show tables', function(err, tables) {
+        if (err) return callback(err);
 
-      if(length === 0) {
-        // The database is empty
-        return callback();
-      }
+        var database = db.config.connectionConfig ?
+            db.config.connectionConfig.database : db.config.database;
 
-      tables.forEach(function(table) {
-        if (skippedTables.indexOf(table[tableName]) === -1) {
-          var statement = strategy === 'deletion' ? 'DELETE FROM ' : 'TRUNCATE TABLE '
-          db.query(statement + table[tableName], function(err) {
-            if(err) {
-              return callback(err);
-            }
+        var count  = 0;
+        var length = tables.length;
+        var tableName = 'Tables_in_' + (lowerCaseTableNames ? database.toLowerCase() : database);
+        var skippedTables = config.mysql.skipTables;
+        var strategy = config.mysql.strategy || 'deletion';
+        if (strategy !== 'deletion' && strategy !== 'truncation') {
+          return callback(new Error('Invalid deletion strategy: ' + strategy));
+        }
 
+        if(length === 0) {
+          // The database is empty
+          return callback();
+        }
+
+        tables.forEach(function(table) {
+          if (skippedTables.indexOf(table[tableName]) === -1) {
+            var statement = strategy === 'deletion' ? 'DELETE FROM ' : 'TRUNCATE TABLE '
+            db.query(statement + table[tableName], function(err) {
+              if(err) {
+                return callback(err);
+              }
+
+              count++;
+              if (count >= length) {
+                callback();
+              }
+            });
+          } else {
             count++;
             if (count >= length) {
               callback();
             }
-          });
-        } else {
-          count++;
-          if (count >= length) {
-            callback();
           }
-        }
+        });
       });
     });
   };

--- a/lib/database-cleaner.js
+++ b/lib/database-cleaner.js
@@ -47,49 +47,53 @@ var DatabaseCleaner = module.exports = function(type, config) {
   };
 
   cleaner['mysql'] = function(db, callback) {
-    db.query('show global variables like "lower_case_table_names"', function(err, values) {
+    db.query('SET FOREIGN_KEY_CHECKS = 0', function(err) {
+      if (err) return callback(err);
 
-      var lowerCaseTableNames = values[0]['Value'] === 2;
+      db.query('show global variables like "lower_case_table_names"', function(err, values) {
 
-      db.query('show tables', function(err, tables) {
-        if (err) return callback(err);
+        var lowerCaseTableNames = values[0]['Value'] === 2;
 
-        var database = db.config.connectionConfig ?
-            db.config.connectionConfig.database : db.config.database;
+        db.query('show full tables where Table_Type != "VIEW"', function(err, tables) {
+          if (err) return callback(err);
 
-        var count  = 0;
-        var length = tables.length;
-        var tableName = 'Tables_in_' + (lowerCaseTableNames ? database.toLowerCase() : database);
-        var skippedTables = config.mysql.skipTables;
-        var strategy = config.mysql.strategy || 'deletion';
-        if (strategy !== 'deletion' && strategy !== 'truncation') {
-          return callback(new Error('Invalid deletion strategy: ' + strategy));
-        }
+          var database = db.config.connectionConfig ?
+              db.config.connectionConfig.database : db.config.database;
 
-        if(length === 0) {
-          // The database is empty
-          return callback();
-        }
+          var count  = 0;
+          var length = tables.length;
+          var tableName = 'Tables_in_' + (lowerCaseTableNames ? database.toLowerCase() : database);
+          var skippedTables = config.mysql.skipTables;
+          var strategy = config.mysql.strategy || 'deletion';
+          if (strategy !== 'deletion' && strategy !== 'truncation') {
+            return callback(new Error('Invalid deletion strategy: ' + strategy));
+          }
 
-        tables.forEach(function(table) {
-          if (skippedTables.indexOf(table[tableName]) === -1) {
-            var statement = strategy === 'deletion' ? 'DELETE FROM ' : 'TRUNCATE TABLE '
-            db.query(statement + table[tableName], function(err) {
-              if(err) {
-                return callback(err);
-              }
+          if(length === 0) {
+            // The database is empty
+            return callback();
+          }
 
+          tables.forEach(function(table) {
+            if (skippedTables.indexOf(table[tableName]) === -1) {
+              var statement = (strategy === 'deletion') ? 'DELETE FROM ' : 'TRUNCATE TABLE ';
+              db.query(statement + table[tableName], function(err) {
+                if(err) {
+                  return callback(err);
+                }
+
+                count++;
+                if (count >= length) {
+                  callback();
+                }
+              });
+            } else {
               count++;
               if (count >= length) {
                 callback();
               }
-            });
-          } else {
-            count++;
-            if (count >= length) {
-              callback();
             }
-          }
+          });
         });
       });
     });

--- a/test/mysql.test.js
+++ b/test/mysql.test.js
@@ -4,17 +4,14 @@ var should = require('should'),
     async = require('async'),
     databaseCleaner;
 
+var config = {
+  host: process.env.MYSQL_HOST || 'localhost',
+  user: 'root',
+  database: 'database_cleaner'
+}
 var mysql = require('mysql'),
-    client = new mysql.createConnection({
-      host: process.env.MYSQL_HOST || 'localhost',
-      user: 'root',
-      database: 'database_cleaner'
-    }),
-    pool = new mysql.createPool({
-      host: process.env.MYSQL_HOST || 'localhost',
-      user: 'root',
-      database: 'database_cleaner'
-    });
+    client = new mysql.createConnection(config),
+    pool = new mysql.createPool(config);
 
 var queryClient = _.curry(function(query, values, next) {
   client.query(query, values, next);
@@ -22,7 +19,7 @@ var queryClient = _.curry(function(query, values, next) {
 
 describe('mysql', function() {
   beforeEach(function(done) {
-    client.query('CREATE DATABASE database_cleaner', function(err) {
+    client.query('CREATE DATABASE ' + config.database, function(err) {
       if (err && err.number != mysql.ERROR_DB_CREATE_EXISTS) {
         throw err;
       }
@@ -145,7 +142,7 @@ describe('mysql', function() {
 
 describe('mysql empty', function() {
    beforeEach(function(done) {
-    client.query('CREATE DATABASE database_cleaner', function(err) {
+    client.query('CREATE DATABASE ' + config.database, function(err) {
       if (err && err.number != mysql.ERROR_DB_CREATE_EXISTS) {
         throw err;
       }


### PR DESCRIPTION
Currently in MySQL if lower_case_table_names is set to 2 then when your database name has an uppercase character database-cleaner will fail because the `show tables` query returns using a column of `Tables_in_<lowercase DB name>`

Also, if you have views, it will fail. 

Also, if any tables have foreign key constraints, it will fail.

* Check the value of lower_case_table_names and if it is 2 then lowercasing the database name when constructing the expected column name seems to fix it.

* Exclude views when getting table names to truncate so that it doesn't error on them.

* Disable foreign key checks so that it doesn't fail on them